### PR TITLE
Implement regex to DFA and graph to NFA conversions

### DIFF
--- a/project/task1_graph_utilities.py
+++ b/project/task1_graph_utilities.py
@@ -12,9 +12,22 @@ class GraphInfo:
     edge_labels: List[str]
 
 
-def get_graph_info_by_name(name: str) -> GraphInfo:
+def get_graph_by_name(name: str) -> nx.MultiDiGraph:
     path = cfpq_data.download(name)
-    graph = cfpq_data.graph_from_csv(path)
+    return cfpq_data.graph_from_csv(path)
+
+
+def get_graph_info_by_name(name: str) -> GraphInfo:
+    graph = get_graph_by_name(name)
+    return GraphInfo(
+        nodes_num=graph.number_of_nodes(),
+        edges_num=graph.number_of_edges(),
+        edge_labels=cfpq_data.get_sorted_labels(graph),
+    )
+
+
+# a helper function useful for tests
+def get_graph_info_from_graph(graph: nx.MultiDiGraph):
     return GraphInfo(
         nodes_num=graph.number_of_nodes(),
         edges_num=graph.number_of_edges(),

--- a/project/task2_automata_conversions.py
+++ b/project/task2_automata_conversions.py
@@ -1,0 +1,40 @@
+from typing import Set
+from pyformlang.finite_automaton import (
+    DeterministicFiniteAutomaton,
+    NondeterministicFiniteAutomaton,
+    State,
+    Symbol,
+)
+from pyformlang.regular_expression import Regex
+from networkx import MultiDiGraph
+
+
+def regex_to_dfa(regex: str) -> DeterministicFiniteAutomaton:
+    epsinlon_nfa = Regex(regex).to_epsilon_nfa()
+    return epsinlon_nfa.minimize()
+
+
+def nodes_to_states(graph: MultiDiGraph) -> dict[int, State]:
+    return {int(node): State(int(node)) for node in graph.nodes}
+
+
+def graph_to_nfa(
+    graph: MultiDiGraph, start_states: Set[int], final_states: Set[int]
+) -> NondeterministicFiniteAutomaton:
+    state_map = nodes_to_states(graph)
+    states = set(state_map.values())
+    if not start_states:
+        start_states = states
+    if not final_states:
+        final_states = states
+
+    nfa = NondeterministicFiniteAutomaton(
+        states=states, start_state=start_states, final_states=final_states
+    )
+
+    for v1, v2, label in graph.edges(data="label"):
+        s_from, s_to, symbol = int(v1), int(v2), label
+        if label is None:
+            symbol = "$"
+        nfa.add_transition(state_map[s_from], Symbol(symbol), state_map[s_to])
+    return nfa

--- a/tests/autotests/test_task02.py
+++ b/tests/autotests/test_task02.py
@@ -14,7 +14,7 @@ from grammars_constants import REGEXES
 
 # Fix import statements in try block to run tests
 try:
-    from project.task2 import regex_to_dfa, graph_to_nfa
+    from project.task2_automata_conversions import regex_to_dfa, graph_to_nfa
 except ImportError:
     pytestmark = pytest.mark.skip("Task 2 is not ready to test!")
 

--- a/tests/test_task1_graph_utilities.py
+++ b/tests/test_task1_graph_utilities.py
@@ -1,20 +1,12 @@
-from pathlib import Path
 import pytest
 from project.task1_graph_utilities import (
     get_graph_info_by_name,
     build_graph_from_two_cycles,
     save_graph_from_two_cycles_to_dot_file,
 )
-from utilities import get_graph_info_from_json
+from utilities import get_graph_info_from_json, GRAPH_PARAMS
 from networkx.drawing.nx_pydot import read_dot
 from networkx.algorithms.isomorphism import is_isomorphic, categorical_edge_match
-
-
-DATA_DIR = Path(__file__).parent / "resources/graph_datasets"
-
-GRAPH_NAMES = ["biomedical", "pathways", "wine"]
-
-GRAPH_PARAMS = [(name, DATA_DIR / f"{name}_graph_info.json") for name in GRAPH_NAMES]
 
 
 @pytest.mark.parametrize("graph_name, path_to_graph", GRAPH_PARAMS)

--- a/tests/test_task2_automata_conversions.py
+++ b/tests/test_task2_automata_conversions.py
@@ -1,0 +1,102 @@
+import random
+from networkx import MultiDiGraph
+import pytest
+import string
+from pyformlang.regular_expression import MisformedRegexError
+from project.task2_automata_conversions import regex_to_dfa, graph_to_nfa
+from project.task1_graph_utilities import (
+    get_graph_by_name,
+    save_graph_from_two_cycles_to_dot_file,
+    get_graph_info_from_graph,
+)
+from networkx.drawing.nx_pydot import read_dot
+from utilities import GRAPH_PARAMS
+
+
+class TestRegexToDfa:
+    def test_empty_regex(self):
+        dfa = regex_to_dfa("")
+        assert dfa.is_empty()
+
+    def test_only_accepts_epsilon(self):
+        dfa = regex_to_dfa("$")
+        assert dfa.accepts("")
+        word = random.choice(string.punctuation)
+        assert not dfa.accepts(word)
+
+    def test_misformed_regex(self):
+        with pytest.raises(MisformedRegexError):
+            regex_to_dfa(" ( * ")
+
+    def test_dfa_equivalence(self):
+        dfa1 = regex_to_dfa("(a|b)*")
+        dfa2 = regex_to_dfa("(a*b*)*")
+        assert dfa1.is_equivalent_to(dfa2)
+
+
+class TestGraphToNfa:
+    def test_empty_graph(self):
+        graph = MultiDiGraph()
+        nfa = graph_to_nfa(graph, set(), set())
+        assert nfa.is_empty()
+
+    def test_graph_with_one_node(self):
+        graph = MultiDiGraph()
+        graph.add_node(0)
+        # if the node is start+final, then nfa should accept epsilon
+        nfa = graph_to_nfa(graph, set(), set())
+        assert nfa.accepts("")
+        # if the node is not start+final, then nfa should be empty
+        nfa = graph_to_nfa(graph, {1}, {2})
+        word = random.choice(string.punctuation)
+        assert not nfa.accepts(word)
+
+    @pytest.mark.parametrize(
+        "node_num1, node_num2, labels",
+        [(1, 1, ("hi", ",")), (4, 5, ("it", "is")), (100, 200, ("tea", "time"))],
+    )
+    def test_graph_from_dot(self, node_num1, node_num2, labels, tmp_path):
+        path = tmp_path / "graph.dot"
+        save_graph_from_two_cycles_to_dot_file(node_num1, node_num2, labels, path)
+        graph = read_dot(path)
+        nfa = graph_to_nfa(graph, set(), set())
+        assert nfa.start_states == nfa.final_states == nfa.states
+        assert len(nfa.states) == node_num1 + node_num2 + 1
+        graph_info = get_graph_info_from_graph(graph)
+        assert nfa.symbols == set(graph_info.edge_labels)
+        assert nfa.get_number_transitions() == graph_info.edges_num
+
+    @pytest.mark.parametrize("graph_name, path_to_graph", GRAPH_PARAMS)
+    def test_graph_from_dataset(self, graph_name, path_to_graph):
+        graph = get_graph_by_name(graph_name)
+        graph_info = get_graph_info_from_graph(graph)
+        nfa = graph_to_nfa(graph, set(), set())
+        assert nfa.start_states == nfa.final_states == nfa.states
+        assert len(nfa.states) == graph_info.nodes_num
+        assert nfa.get_number_transitions() == graph_info.edges_num
+
+    def test_graph_distinct_final_and_start_states(self):
+        graph = MultiDiGraph()
+        graph.add_nodes_from([0, 1, 2, 3])
+        graph.add_edges_from([(0, 1), (1, 3), (3, 2)])
+        nfa = graph_to_nfa(graph, {0, 1}, {2, 3})
+        # no node is start+final, so nfa should not accept epsilon
+        assert not nfa.accepts("")
+
+    def test_disconnected_graph(self):
+        graph = MultiDiGraph()
+        graph.add_nodes_from([0, 1, 2, 3])
+        graph.add_edges_from([(0, 1), (1, 3), (3, 0)])
+        nfa = graph_to_nfa(
+            graph, {1}, {2}
+        )  # start state in one component, final state in another
+        assert nfa.is_empty()
+
+    def test_parallel_edges(self):
+        graph = MultiDiGraph()
+        graph.add_edge(0, 1, label="a")
+        graph.add_edge(0, 1, label="b")
+        nfa = graph_to_nfa(graph, {0}, {1})
+        # nfa should accept both "a" and "b"
+        assert nfa.accepts("a")
+        assert nfa.accepts("b")

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -1,5 +1,13 @@
 import json
+from pathlib import Path
 from project.task1_graph_utilities import GraphInfo
+
+
+DATA_DIR = Path(__file__).parent / "resources/graph_datasets"
+
+GRAPH_NAMES = ["biomedical", "pathways", "wine"]
+
+GRAPH_PARAMS = [(name, DATA_DIR / f"{name}_graph_info.json") for name in GRAPH_NAMES]
 
 
 def get_graph_info_from_json(path: str) -> GraphInfo:


### PR DESCRIPTION
This module provides two functions for working with automata using the `pyformlang` library:
* regular expression to DFA conversion
  * transforms a given regular expression into a minimal deterministic finite automaton
  * supports the standard regex format accepted by `pyformlang`
* graph to NFA conversion
  * builds a nondeterministic finite automaton from a directed multigraph
  * supports graphs obtained from dataset loading by name and generated graphs (as implemented in task 1)
  * allows explicit specification of start and final states (if not provided, all vertices are considered both start and final states)

Added unit tests for both conversions